### PR TITLE
Change default log level in template to INFO

### DIFF
--- a/config/functions.cfg
+++ b/config/functions.cfg
@@ -121,7 +121,7 @@ function systemd {
   [Service]
   User=$CUSTOM_USER
   WorkingDirectory=$WORKDIR
-  ExecStart=$WORKDIR/node -use-log-view -log-level *:DEBUG -rest-api-interface localhost:$APIPORT $NODE_EXTRA_FLAGS
+  ExecStart=$WORKDIR/node -use-log-view -log-level *:INFO -rest-api-interface localhost:$APIPORT $NODE_EXTRA_FLAGS
   StandardOutput=journal
   StandardError=journal
   Restart=always


### PR DESCRIPTION
Launching termui without any flags changes log_level for the first node (8080) to INFO.
Proposing changes to make logic more consistent:
- default log_level for unit =  INFO
- want to make analysis - use termui with DEBUG and TRACE