### PR TITLE
Force IPv4 with wget

### DIFF
--- a/config/functions.cfg
+++ b/config/functions.cfg
@@ -75,7 +75,7 @@ function go_lang {
                             echo -e
                             echo -e "${GREEN}Your GO binary will pe upgraded to the minimum required version...${NC}"
                             sudo rm -rf /usr/local/go
-                            wget https://dl.google.com/go/$GO_LATEST.linux-$ARCH.tar.gz
+                            wget -4 https://dl.google.com/go/$GO_LATEST.linux-$ARCH.tar.gz
                             sudo tar -C /usr/local -xzf $GO_LATEST.linux-$ARCH.tar.gz
                             rm $GO_LATEST.linux-$ARCH.tar.gz
 


### PR DESCRIPTION
The download of the Go upgrade tar.gz file can time out if IPv4 isn't forced.