### PR TITLE
missing killall dependency

### DIFF
--- a/config/functions.cfg
+++ b/config/functions.cfg
@@ -10,7 +10,7 @@ function prerequisites {
   
   if [[ $DISTRO == *"linuxmint"* ]] || [[ $DISTRO == *"ubuntu"* ]] || [[ $DISTRO == *"debian"* ]] || [[ $DISTRO == *"elementary"* ]]; then
                                       sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq && sudo DEBIAN_FRONTEND=noninteractive apt-get -qy -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade > /dev/null
-                                      sudo DEBIAN_FRONTEND=noninteractive apt-get -qy -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install build-essential > /dev/null && sudo DEBIAN_FRONTEND=noninteractive apt-get -qy -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install git rsync curl zip unzip jq gcc wget > /dev/null
+                                      sudo DEBIAN_FRONTEND=noninteractive apt-get -qy -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install build-essential > /dev/null && sudo DEBIAN_FRONTEND=noninteractive apt-get -qy -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install psmisc git rsync curl zip unzip jq gcc wget > /dev/null
                                       echo "export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin" >> ~/.profile
                                       echo "export GOPATH=$HOME/go" >> ~/.profile
                                   else 


### PR DESCRIPTION
Was getting a missing killall while upgrading to v1.1.43, which made the upgrade flow fail.
Installing psmisc and retrying it a few times eventually resolved it.